### PR TITLE
Additional boards added

### DIFF
--- a/Template/Community/boards/mobiflight_template_micro.board.json
+++ b/Template/Community/boards/mobiflight_template_micro.board.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "Attempts": 1,
+    "BaudRates": [ "57600" ],
+    "Device": "atmega32u4",
+    "Programmer": "avr109",
+    "Timeout": 15000
+  },
+  "Connection": {
+    "ConnectionDelay": 1250,
+    "DelayAfterFirmwareUpdate": 1250,
+    "DtrEnable": true,
+    "EEPROMSize": 440,
+    "ExtraConnectionRetry": false,
+    "ForceResetOnFirmwareUpdate": true,
+    "MessageSize": 64
+  },
+  "HardwareIds": [
+    "^VID_1B4F&PID_9206",
+    "^VID_2341&PID_8036",
+    "^VID_2341&PID_8037"
+  ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "CanResetBoard": true,
+    "FirmwareBaseName": "mobiflight_micro",
+    "FirmwareExtension": "hex",
+    "FriendlyName": "Arduino Pro Micro",
+    "LatestFirmwareVersion": "2.5.1",
+    "MobiFlightType": "MobiFlight Template Micro",
+    "ResetFirmwareFile": "reset.arduino_promicro_1_0_2.hex"
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 9,
+    "MaxButtons": 18,
+    "MaxEncoders": 9,
+    "MaxInputShifters": 6,
+    "MaxLcdI2C": 2,
+    "MaxLedSegments": 6,
+    "MaxOutputs": 18,
+    "MaxServos": 8,
+    "MaxShifters": 6,
+    "MaxSteppers": 4,
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices": 0
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 0
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 1
+    },
+    {
+      "isAnalog": false,
+      "isI2C": true,
+      "isPWM": false,
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": true,
+      "isPWM": true,
+      "Pin": 3
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 5
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 7
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 8
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 9
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 14
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 15
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 16
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 18,
+      "Name": "A0"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 19,
+      "Name": "A1"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 20,
+      "Name": "A2"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 21,
+      "Name": "A3"
+    }
+  ]
+}

--- a/Template/Community/boards/mobiflight_template_nano.board.json
+++ b/Template/Community/boards/mobiflight_template_nano.board.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "Attempts": 1,
+    "Device": "atmega328p",
+    "BaudRates": ["115200", "57600"],
+    "Programmer": "arduino",
+    "Timeout": 20000
+  },
+  "Connection": {
+    "ConnectionDelay": 1750,
+    "DelayAfterFirmwareUpdate": 0,
+    "DtrEnable": true,
+    "EEPROMSize": 286,
+    "ExtraConnectionRetry": true,
+    "ForceResetOnFirmwareUpdate": false,
+    "MessageSize": 64,
+    "TimeoutForFirmwareUpdate": 60000
+  },
+  "HardwareIds": [
+    "^VID_2341&PID_0043",
+    "^VID_2A03&PID_0043",
+    "^VID_2341&PID_0243",
+    "^VID_2341&PID_0001",
+    "^VID_1A86&PID_7523",
+    "^VID_0403&PID_6001",
+    "^VID_067B&PID_2303",
+    "^VID_0403\\+PID_6001\\+.+"
+  ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "CanResetBoard": true,
+    "FirmwareBaseName": "mobiflight_nano",
+    "FirmwareExtension": "hex",
+    "FriendlyName": "Arduino Nano",
+    "LatestFirmwareVersion": "2.5.1",
+    "MobiFlightType": "MobiFlight Template Nano",
+    "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 8,
+    "MaxButtons": 18,
+    "MaxEncoders": 9,
+    "MaxInputShifters": 6,
+    "MaxLcdI2C": 2,
+    "MaxLedSegments": 6,
+    "MaxOutputs": 18,
+    "MaxServos": 8,
+    "MaxShifters": 6,
+    "MaxSteppers": 4,
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices": 0
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 3
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 5
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 7
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 8
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 11
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 12
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 13
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A0",
+      "Pin": 14
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A1",
+      "Pin": 15
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A2",
+      "Pin": 16
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A3",
+      "Pin": 17
+    },
+    {
+      "isAnalog": true,
+      "isI2C": true,
+      "isPWM": false,
+      "Name": "A4",
+      "Pin": 18
+    },
+    {
+      "isAnalog": true,
+      "isI2C": true,
+      "isPWM": false,
+      "Name": "A5",
+      "Pin": 19
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A6",
+      "Pin": 20
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A7",
+      "Pin": 21
+    }
+  ]
+}

--- a/Template/Community/boards/mobiflight_template_uno.board.json
+++ b/Template/Community/boards/mobiflight_template_uno.board.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "Attempts": 1,
+    "Device": "atmega328p",
+    "BaudRates": ["115200"],
+    "Programmer": "arduino",
+    "Timeout": 15000
+  },
+  "Connection": {
+    "ConnectionDelay": 1750,
+    "DelayAfterFirmwareUpdate": 0,
+    "DtrEnable": true,
+    "EEPROMSize": 286,
+    "ExtraConnectionRetry": true,
+    "ForceResetOnFirmwareUpdate": false,
+    "MessageSize": 64
+  },
+  "HardwareIds": [
+    "^VID_10C4&PID_EA60",
+    "^VID_2341&PID_0043",
+    "^VID_2A03&PID_0043",
+    "^VID_2341&PID_0243",
+    "^VID_2341&PID_0001",
+    "^VID_1A86&PID_7523",
+    "^VID_0403&PID_6001",
+    "^VID_0403\\+PID_6001\\+.+"
+  ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "CanResetBoard": true,
+    "FriendlyName": "Arduino Uno",
+    "FirmwareBaseName": "mobiflight_uno",
+    "FirmwareExtension": "hex",
+    "LatestFirmwareVersion": "2.5.1",
+    "MobiFlightType": "MobiFlight Template Uno",
+    "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 6,
+    "MaxButtons": 18,
+    "MaxEncoders": 9,
+    "MaxInputShifters": 6,
+    "MaxLcdI2C": 2,
+    "MaxLedSegments": 6,
+    "MaxOutputs": 18,
+    "MaxServos": 8,
+    "MaxShifters": 6,
+    "MaxSteppers": 4,
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices": 0
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 3
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 5
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 7
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 8
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 11
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 12
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 13
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A0",
+      "Pin": 14
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A1",
+      "Pin": 15
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A2",
+      "Pin": 16
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Name": "A3",
+      "Pin": 17
+    },
+    {
+      "isAnalog": true,
+      "isI2C": true,
+      "isPWM": false,
+      "Name": "A4",
+      "Pin": 18
+    },
+    {
+      "isAnalog": true,
+      "isI2C": true,
+      "isPWM": false,
+      "Name": "A5",
+      "Pin": 19
+    }
+  ]
+}

--- a/Template/MyCustomDevice_platformio.ini
+++ b/Template/MyCustomDevice_platformio.ini
@@ -23,11 +23,85 @@ custom_community_project = Your_Project								; Should match "Project" from sec
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
-; nothing needs to be changed above this line
 build_flags = 
 	${env_template.build_flags}										; don't change this one!
 	-I./src/_Boards/Atmel/Board_Mega								; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	'-DMOBIFLIGHT_TYPE="Mobiflight Template Mega"'					; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Mobiflight Template"' 						; this will show up as Name in the settings dialog unless it gets change from there
+build_src_filter = 
+	${env.build_src_filter}											; don't change this one!
+	${env_template.build_src_filter}								; don't change this one!
+lib_deps = 
+	${env.lib_deps}													; don't change this one!
+	${env.custom_lib_deps_Atmel}									; don't change this one!
+	${env_template.lib_deps}										; don't change this one!
+monitor_speed = 115200												; don't change this one!
+extra_scripts = 
+	${env.extra_scripts}											; don't change this one!
+custom_core_firmware_version = ${env_template.custom_core_firmware_version}	; don't change this one!
+custom_community_project = ${env_template.custom_community_project}			; don't change this one!
+custom_device_folder = ${env_template.custom_device_folder}					; don't change this one!
+
+
+; Build settings for the Arduino ProMicro with Custom Firmware Template
+[env:mobiflight_template_micro]
+platform = atmelavr
+board = sparkfun_promicro16
+framework = arduino
+build_flags = 
+	${env_template.build_flags}										; don't change this one!
+	-I./src/_Boards/Atmel/Board_Mega								; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
+	'-DMOBIFLIGHT_TYPE="Mobiflight Template Micro"'					; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Mobiflight Template"' 						; this will show up as Name in the settings dialog unless it gets change from there
+build_src_filter = 
+	${env.build_src_filter}											; don't change this one!
+	${env_template.build_src_filter}								; don't change this one!
+lib_deps = 
+	${env.lib_deps}													; don't change this one!
+	${env.custom_lib_deps_Atmel}									; don't change this one!
+	${env_template.lib_deps}										; don't change this one!
+monitor_speed = 115200												; don't change this one!
+extra_scripts = 
+	${env.extra_scripts}											; don't change this one!
+custom_core_firmware_version = ${env_template.custom_core_firmware_version}	; don't change this one!
+custom_community_project = ${env_template.custom_community_project}			; don't change this one!
+custom_device_folder = ${env_template.custom_device_folder}					; don't change this one!
+
+
+; Build settings for the Arduino Uno with Custom Firmware Template
+[env:mobiflight_template_uno]
+platform = atmelavr
+board = uno
+framework = arduino
+build_flags = 
+	${env_template.build_flags}										; don't change this one!
+	-I./src/_Boards/Atmel/Board_Mega								; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
+	'-DMOBIFLIGHT_TYPE="Mobiflight Template Uno"'					; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Mobiflight Template"' 						; this will show up as Name in the settings dialog unless it gets change from there
+build_src_filter = 
+	${env.build_src_filter}											; don't change this one!
+	${env_template.build_src_filter}								; don't change this one!
+lib_deps = 
+	${env.lib_deps}													; don't change this one!
+	${env.custom_lib_deps_Atmel}									; don't change this one!
+	${env_template.lib_deps}										; don't change this one!
+monitor_speed = 115200												; don't change this one!
+extra_scripts = 
+	${env.extra_scripts}											; don't change this one!
+custom_core_firmware_version = ${env_template.custom_core_firmware_version}	; don't change this one!
+custom_community_project = ${env_template.custom_community_project}			; don't change this one!
+custom_device_folder = ${env_template.custom_device_folder}					; don't change this one!
+
+
+; Build settings for the Arduino Nano with Custom Firmware Template
+[env:mobiflight_template_nano]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+build_flags = 
+	${env_template.build_flags}										; don't change this one!
+	-I./src/_Boards/Atmel/Board_Mega								; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
+	'-DMOBIFLIGHT_TYPE="Mobiflight Template Nano"'					; this must match with "MobiFlightType" within the .json file
 	'-DMOBIFLIGHT_NAME="Mobiflight Template"' 						; this will show up as Name in the settings dialog unless it gets change from there
 build_src_filter = 
 	${env.build_src_filter}											; don't change this one!
@@ -53,7 +127,6 @@ board_build.core = earlephilhower
 board_build.filesystem_size = 0M
 lib_ldf_mode = chain+
 upload_protocol = mbed
-; nothing needs to be changed above this line
 build_flags =
 	${env_template.build_flags}										; don't change this one!
 	-I./src/_Boards/RaspberryPi/Pico								; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)


### PR DESCRIPTION
## Description of changes

The available core boards ProMicro, Uno and Nano are added in MyCustomDevice_platformio.ini and the required json are added. The reset files were already available.
