### PR TITLE
Define for folder name within zip file

### DIFF
--- a/Template/MyCustomDevice_platformio.ini
+++ b/Template/MyCustomDevice_platformio.ini
@@ -15,8 +15,8 @@ build_src_filter =
 lib_deps =															; You can add additional libraries if required
 custom_core_firmware_version = 2.5.1								; define the version from the core firmware files your build should base on
 custom_device_folder = Template										; path to your Custom Device Sources, replace "Template" by your folder name
-custom_community_project = Your_Project								; Should match "Project" from section "Community" within the board.json file, it's the name of the ZIP file
-
+custom_community_project = Your_Project								; name of the ZIP file, revision will be added during build process
+custom_community_folder = Your_Folder_Name							; Folder name inside zip fileShould match "Project" from section "Community" within the board.json file
 
 ; Build settings for the Arduino Mega with Custom Firmware Template
 [env:mobiflight_template_mega]

--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -15,6 +15,9 @@ community_project = env.GetProjectOption('custom_community_project', "")
 # Get the custom folder from the build environment.
 custom_device_folder = env.GetProjectOption('custom_device_folder', "")
 
+# Get the foldername inside the zip file from the build environment.
+community_folder = env.GetProjectOption('custom_community_folder', "")
+
 
 def copy_fw_files (source, target, env):
     fw_file_name=str(target[0])
@@ -33,7 +36,7 @@ def copy_fw_files (source, target, env):
 def createCommunityZipFile(source, target, env):
     original_folder_path = "./_build/" + custom_device_folder + "/Community"
     zip_file_path = './_dist/' + community_project + '_' + firmware_version + '.zip'
-    new_folder_in_zip = community_project
+    new_folder_in_zip = community_folder
     createZIP(original_folder_path, zip_file_path, new_folder_in_zip)
 
 def createZIP(original_folder_path, zip_file_path, new_folder_name):


### PR DESCRIPTION
## Description of changes

For multiple community devices from one supporter/user it is sensefull to have the files for all these community devices within one folder (like GNC255 and I2C from Mobiflight).
With this change the zip file name and the folder within the zip file can be different, e.g.
* `Device_1_1.0.0.zip` is a 'speaken' file name, the folder within the zip could be `User`
* `Device_2_1.0.0.zip` is a 'speaken' file name, the folder within the zip could be `User`

So the files for both devices will be within the folder `/community/User/...`.