### PR TITLE
config can be read additionally from Flash

### DIFF
--- a/Template/MFCustomDevice.h
+++ b/Template/MFCustomDevice.h
@@ -12,13 +12,13 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
-    void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
+    void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig, bool configFromFlash = false);
     void detach();
     void update();
     void set(int16_t messageID, char *setPoint);
 
 private:
-    bool           getStringFromEEPROM(uint16_t addreeprom, char *buffer);
+    bool           getStringFromEEPROM(uint16_t addreeprom, char *buffer, bool configFromFlash);
     bool           _initialized = false;
     MyCustomClass *_mydevice;
     uint8_t        _pin1, _pin2, _pin3;

--- a/Template/MFCustomDevicesConfig.h
+++ b/Template/MFCustomDevicesConfig.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Define your input custom devices and uncomment -DHAS_CONFIG_IN_FLASH
+// in your MFCustomDevice_platformio.ini
+const char CustomDeviceConfig[] PROGMEM =
+    {
+        "1.2.Button Flash:"
+        "8.3.4.0.Encoder Flash:"
+        "11.54.5.Analog Input Flash:"
+        "12.7.6.5.1.InputShifter Flash:"
+        "14.12.8.9.10.11.2.Multiplexer Flash:"};

--- a/Template/MyCustomDevice_platformio.ini
+++ b/Template/MyCustomDevice_platformio.ini
@@ -8,6 +8,7 @@ build_flags =
 	-DMF_CUSTOMDEVICE_SUPPORT=1										; Required for Custom Devices
 	;-DMF_CUSTOMDEVICE_HAS_UPDATE									; if the custom device needs to be updated, uncomment this. W/o the following define it will be done each loop()
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 									; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
+	;-DHAS_CONFIG_IN_FLASH											; undefine this and add your configuration to MFCustomDevicesConfig.h to save the config in Flash !!Core FW version must be at least 2.5.2!!
 	-I./src/src/MF_CustomDevice										; don't change this one!
 	-I./Template													; Include files for your custom device, replace "Template" by your folder name
 build_src_filter = 


### PR DESCRIPTION
## Description of changes

These are the changes to read a configuration from Flash and/or EEPROM for a communit device.
The configuration saved in Flash must be in `MFCustomDevicesConfig.h` like:
```
const char CustomDeviceConfig[] PROGMEM =
    {
        "1.2.Button Flash:"
        "8.3.4.0.Encoder Flash:"
        "11.54.5.Analog Input Flash:"
        "12.7.6.5.1.InputShifter Flash:"
        "14.12.8.9.10.11.2.Multiplexer Flash:"};
```
If the compile flag `-DHAS_CONFIG_IN_FLASH` is set, this configuration gets read first, afterwards a configuration saved in the EEPROM gets read.
Precondition is that PR [PR324](https://github.com/MobiFlight/MobiFlight-FirmwareSource/pull/324) is merged. If not, the configuration will not be read from flash, only from EEPROM.

Fixes #7 